### PR TITLE
feat(feeds): add AS197817 (Nyco Cloud Network)

### DIFF
--- a/feeds/AS197817.yml
+++ b/feeds/AS197817.yml
@@ -1,0 +1,8 @@
+name: "Nyco Cloud Network"
+
+asn: "AS197817"
+
+contact: "noc@nyco.cloud"
+
+geofeed_urls:
+  - "https://nyco.cloud/geofeed.csv"


### PR DESCRIPTION
Geofeed for AS197817 PoP prefixes under 2a14:ae00::/29. URL: https://nyco.cloud/geofeed.csv (RFC 8805, served 200).