### PR TITLE
Add AS199794 (EMOCLOUD LTD) geofeed - Tokyo

### DIFF
--- a/feeds/AS199794.yml
+++ b/feeds/AS199794.yml
@@ -1,0 +1,10 @@
+# ============================================================
+#  Geofeed for AS199794 (EMOCLOUD LTD)
+#  Tokyo IP range
+# ============================================================
+
+name: "EMOCLOUD LTD"
+asn: "AS199794"
+contact: "abuse@emocloud.co"
+geofeed_urls:
+  - "https://api.emocloud.co/geofeed.csv"


### PR DESCRIPTION
## Summary

Add geofeed for AS199794 (EMOCLOUD LTD).

- **ASN**: AS199794
- **Organization**: EMOCLOUD LTD
- **Contact**: abuse@emocloud.co
- **Geofeed URL**: https://api.emocloud.co/geofeed.csv
- **IP Range**: 194.62.119.0/24 → Tokyo, JP

The geofeed CSV is RFC 8805 compliant and publicly accessible.