### PR TITLE
Add geofeed for AS218883 (Melspectrum Technology Co., Ltd.)

### DIFF
--- a/feeds/AS218883.yml
+++ b/feeds/AS218883.yml
@@ -1,0 +1,18 @@
+# ============================================================
+#  Geofeed 提交模板 / Geofeed Submission Template
+# ============================================================
+
+# 组织名称 / Organization Name
+name: "Melspectrum Technology Co., Ltd."
+
+# 自治系统号 / Autonomous System Number
+asn: "AS218883"
+
+# 联系邮箱 / Contact Email
+contact: "contact@melspectrum.com"
+
+# Geofeed URL 列表 / Geofeed URL List
+# 支持多个 URL，每个 URL 应指向一个符合 RFC 8805 标准的 CSV 文件
+# Multiple URLs supported, each should point to an RFC 8805 compliant CSV file
+geofeed_urls:
+  - "https://geofeed.melspectrum.com/geofeed.csv"


### PR DESCRIPTION
Adds `feeds/AS218883.yml`, pointing to our self-hosted RFC 8805 geofeed at
<https://geofeed.melspectrum.com/geofeed.csv>.

### Resources covered

| Prefix | RIR | Relationship |
|---|---|---|
| `2602:f92a:a463::/48` | ARIN | **Simple Reassignment from MoeDove's `2602:f92a::/32`.** ARIN handle `NET6-2602-F92A-A463-1`, NetName `MELSPECTRUM-AS`, Customer `Melspectrum Technology Co., Ltd (C11702128)`. RPKI ROA valid, origin AS218883. |
| `2a13:c8c3:e803::/48` | RIPE | Assigned under AVS ISP LIR sponsorship (`AVS-LIR-8`), `org: ORG-MTCL12-RIPE`. |

Both are originated by **AS218883** (`MELSPECTRUM-AS`, RIPE — `https://rdap.db.ripe.net/autnum/218883`).

Note the cross-RIR split, in case it looks odd at review time: **the ASN is registered
at RIPE while the first prefix is an ARIN object held under MoeDove's allocation.**
The `contact:` address `contact@melspectrum.com` is the publicly visible contact for
AS218883 in the RIPE database.

### Feed details

- HTTPS, dual-stack (A `192.255.139.83` / AAAA `2602:f92a:a463:400::80`), no redirects
- `Content-Type: text/csv; charset=utf-8`, `Cache-Control: public, max-age=86400`
- UTF-8, no BOM, CRLF line endings, 5 fields per row, postal code left empty
  (RFC 8805 marks it OPTIONAL/DEPRECATED)
- Verified 200 over both IPv4 and IPv6 from US / DE / JP / NL / AU probes
- One row uses the RFC 8805 "no location information" form (`prefix,,,,`) for a range of
  roaming personal endpoints that has no stable physical location

Entries are written per-`/56` rather than per-`/48` because the network is multi-POP
(Amsterdam / Los Angeles / Salt Lake City), so no single city is correct for a whole `/48`.
A Hong Kong sub-prefix will be added to the CSV once that POP is deployed.

The commit is unsigned, so automated ownership verification will be skipped and this
needs manual review — we will follow up separately to confirm ownership.