### PR TITLE
docs: align AS199794 geofeed with submission template

### DIFF
--- a/feeds/AS199794.yml
+++ b/feeds/AS199794.yml
@@ -1,10 +1,21 @@
 # ============================================================
-#  Geofeed for AS199794 (EMOCLOUD LTD)
-#  Tokyo IP range
+#  Geofeed 提交模板 / Geofeed Submission Template
+# ============================================================
+#  请复制此文件并重命名为您的 ASN 编号，例如 AS12345.yml
+#  Please copy this file and rename it to your ASN, e.g. AS12345.yml
 # ============================================================
 
+# 组织名称 / Organization Name
 name: "EMOCLOUD LTD"
+
+# 自治系统号 / Autonomous System Number
 asn: "AS199794"
+
+# 联系邮箱 / Contact Email
 contact: "abuse@emocloud.co"
+
+# Geofeed URL 列表 / Geofeed URL List
+# 支持多个 URL，每个 URL 应指向一个符合 RFC 8805 标准的 CSV 文件
+# Multiple URLs supported, each should point to an RFC 8805 compliant CSV file
 geofeed_urls:
   - "https://api.emocloud.co/geofeed.csv"


### PR DESCRIPTION
Align `feeds/AS199794.yml` with the full `feeds/example.yml` layout used by AS203923 and AS213876. Replace the outdated "Tokyo IP range" comment with the standard bilingual header and field descriptions; the current feed includes Tokyo, Tsuen Wan (Hong Kong), and Frankfurt am Main.

The organization, ASN, contact email, and Geofeed URL remain unchanged. This is a documentation and formatting update.

Validation: the repository's `validate_feed.py` and `check_pr_security.py` both passed locally. The URL returned HTTP 200 with `text/csv; charset=utf-8`; all five prefix records passed validation. Parsed YAML values are identical to the existing file, and the layout matches the official template.
